### PR TITLE
Enabled customization of kibana-me-log repo

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 out
 tmp
 .DS_Store
+cf-plugin-kibana-me-logs

--- a/README.md
+++ b/README.md
@@ -41,6 +41,19 @@ It assumes that `<app>` is the an app bound to the same `logstash14` logstash se
 
 `cf kibana-me-logs` will automatically generate a user/password for you to use in conjunction with your kibana-me-logs app, unless you provide the --no-auth option.
 
+Advanced Usage
+--------------
+
+To use a custom kibana-me-logs repo, specify the repo URL in the `KIBANA_ME_LOGS_REPO`
+environment variable.
+
+To bypass cloning kibana-me-logs, and use a local source directory, specify the path in the
+`KIBANA_ME_LOGS_APP_DIR` environment variable.
+
+To use a custom temp directory (overriding `/tmp`), for holding the kibana-me-logs repo being
+pushed, use the `TMP_DIR` environment variable.
+
+
 Development
 -----------
 

--- a/distribution_config.go
+++ b/distribution_config.go
@@ -1,6 +1,16 @@
 package main
 
+import (
+	"os"
+)
+
 // If you fork and change any of these, remember to create your own releases (see README)
 
-// KibanaMeLogsRepo is the repo to clone when auto-creating kibana-me-logs UI apps
-var KibanaMeLogsRepo = "https://github.com/cloudfoundry-community/kibana-me-logs"
+// kibanaMeLogsRepo is the repo to clone when auto-creating kibana-me-logs UI apps
+func kibanaMeLogsRepo() string {
+	var repo = os.Getenv("KIBANA_ME_LOGS_REPO")
+	if repo == "" {
+		repo = "https://github.com/cloudfoundry-community/kibana-me-logs"
+	}
+	return repo
+}


### PR DESCRIPTION
You can now specify a repo URL for grabbing kibana-me-logs
via the `KIBANA_ME_LOGS_REPO` environment variable.

You can also specify using a specific app source directory, and
bypass git cloning with the `KIBANA_ME_LOGS_APP_DIR` environment
variable.
